### PR TITLE
Updating out of date links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@ This documents explains the processes and practices recommended for contributing
 this operator.
 
 - Generally, before developing enhancements to this charm, you should consider [opening an issue
-  ](https://github.com/canonical/openstack-cloud-controller-operator/issues) explaining your use case.
+  ](https://github.com/charmed-kubenretes/openstack-cloud-controller-operator/issues) explaining your use case.
 - If you would like to chat with us about your use-cases or proposed implementation, you can reach
-  us at [Canonical Mattermost public channel](https://chat.charmhub.io/charmhub/channels/charm-dev)
+  us at [Canonical Matrix public channel](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)
   or [Discourse](https://discourse.charmhub.io/).
 - Familiarising yourself with the [Charmed Operator Framework](https://juju.is/docs/sdk) library
   will help you a lot when working on new features or bug fixes.
@@ -31,7 +31,7 @@ source .tox/unit/bin/activate
 ### Testing
 
 ```shell
-tox -e fmt           # update your code according to linting rules
+tox -e format        # update your code according to linting rules
 tox -e lint          # code style
 tox -e unit          # unit tests
 tox -e integration   # integration tests
@@ -54,8 +54,7 @@ juju add-model dev
 # Enable DEBUG logging
 juju model-config logging-config="<root>=INFO;unit=DEBUG"
 # Deploy the charm
-juju deploy ./openstack-cloud-controller-operator_ubuntu-20.04-amd64.charm \
-    --resource operator-base=ubuntu:focal \
+juju deploy ./openstack-cloud-controller-operator_*.charm
 ```
 
 ## Canonical Contributor Agreement

--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ juju relate openstack-cloud-controller:external-cloud-provider  kubernetes-contr
 
 Please see the [Juju SDK docs](https://juju.is/docs/sdk) for guidelines
 on enhancements to this charm following best practice guidelines, and
-[CONTRIBUTING.md](https://github.com/canonical/openstack-cloud-controller-operator/blob/main/CONTRIBUTING.md)
+[CONTRIBUTING.md](https://github.com/charmed-kubiernetes/openstack-cloud-controller-operator/blob/main/CONTRIBUTING.md)
 for developer guidance.


### PR DESCRIPTION
### overview
* re-homing the repo means we need to update links in the README and CONTRIUTING guids