### PR TITLE
Authorize the CCM to have CRD permissions

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -119,7 +119,7 @@ class ProviderCharm(ops.CharmBase):
             self.app.status = ops.ActiveStatus(self.collector.long_version)
 
     def _kube_control(self, event):
-        self.kube_control.set_auth_request(self.unit.name)
+        self.kube_control.set_auth_request(self.unit.name, "system:masters")
         return self._merge_config(event)
 
     def _check_integrator(self, event):


### PR DESCRIPTION
# Overview
* the openstack-cloud-controller needs to have a token worthy enough to write/read CRDs.  kube-control can authorized that.  Let's make the 🤝 

# Details
* adds "system:masters" as the role for the token