### PR TITLE
Allow Juju tf provider to float past 0.14.0

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.14.0"
+      version = ">= 0.14.0, < 1.0.0"
     }
   }
 }


### PR DESCRIPTION
fix: be less specific on juju version of terraform provider to facilitate deployment with juju >= 0.14.0
