### PR TITLE
Accept proxy-config from clients relation and apply to o7k-ccm container

### DIFF
--- a/.github/workflows/charm-build.yaml
+++ b/.github/workflows/charm-build.yaml
@@ -42,8 +42,7 @@ jobs:
       - name: Upload charm artifact
         uses: actions/upload-artifact@v4
         with:
-          name: openstack-integrator.charm
-          path: ./openstack-integrator*.charm
+          path: ./*.charm
       - name: Upload debug artifacts
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -6,11 +6,11 @@ bases:
   - build-on:
       - name: ubuntu
         channel: "22.04"
-        architectures: 
+        architectures:
           - amd64
     run-on:
       - name: ubuntu
-        channel: "20.04"
+        channel: "22.04"
         architectures:
           - amd64
           - arm64

--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,14 @@ options:
         juju config openstack-cloud-controller image-registry='rocks.canonical.com:443/cdk'
         juju config openstack-cloud-controller --reset image-registry
 
+  juju-model-proxy-enable:
+    type: boolean
+    description: |
+      Whether the applications managed by this charm should be
+      proxied using juju's model-config juju-*-proxy settings.
+      (See https://documentation.ubuntu.com/juju/latest/reference/juju-cli/list-of-juju-cli-commands/model-config/).
+    default: false
+
   manager-release:
     type: string
     description: |
@@ -21,13 +29,12 @@ options:
 
       example)
         juju config openstack-cloud-controller manager-release='v1.7.3'
-      
+
       A list of supported versions is available through the action:
         juju run-action openstack-cloud-controller/leader list-releases --wait
-      
+
       To reset by to the latest supported by the charm use:
         juju config openstack-cloud-controller --reset manager-release
-      
+
       The current release deployed is available by viewing
         juju status openstack-cloud-controller
-

--- a/config.yaml
+++ b/config.yaml
@@ -13,7 +13,7 @@ options:
         juju config openstack-cloud-controller image-registry='rocks.canonical.com:443/cdk'
         juju config openstack-cloud-controller --reset image-registry
 
-  juju-model-proxy-enable:
+  web-proxy-enable:
     type: boolean
     description: |
       Whether the applications managed by this charm should be

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydantic==1.*
 ops.interface-kube_control == 0.2.0
 ops.interface-tls-certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@236e089493c96feac5ea1a8617b1059a4477a04e#subdirectory=ops
 ops.interface_openstack_integration @ git+https://github.com/charmed-kubernetes/interface-openstack-integration.git@cf4383999b0920b226104299f4defb3576680d72#subdirectory=ops
+jmodelproxylib @ git+https://github.com/addyess/jmodelproxylib@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-lightkube
-ops
+lightkube==0.17.2
+ops==2.22.0
 ops.manifest>=1.1.3,<2.0.0
 pydantic==1.*
-ops.interface-kube_control == 0.2.0
+ops.interface-kube_control==0.2.0
 ops.interface-tls-certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@236e089493c96feac5ea1a8617b1059a4477a04e#subdirectory=ops
 ops.interface_openstack_integration @ git+https://github.com/charmed-kubernetes/interface-openstack-integration.git@d05f2f1a392cabdd15a1ab8348a0e546c32519f7#subdirectory=ops
-setuptools == 79.0.1
-jmodelproxylib @ git+https://github.com/addyess/jmodelproxylib@main
+charms.proxylib == 0.0.0
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ lightkube
 ops
 ops.manifest>=1.1.3,<2.0.0
 pydantic==1.*
-ops.interface-kube-control @ git+https://github.com/charmed-kubernetes/interface-kube-control.git@ops-0.2.0#subdirectory=ops
+ops.interface-kube_control == 0.2.0
 ops.interface-tls-certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@236e089493c96feac5ea1a8617b1059a4477a04e#subdirectory=ops
-ops.interface_openstack_integration @ git+https://github.com/charmed-kubernetes/interface-openstack-integration.git@d05f2f1a392cabdd15a1ab8348a0e546c32519f7#subdirectory=ops
+ops.interface_openstack_integration @ git+https://github.com/canonical/interface-openstack-integration.git@KU-3229/support-o7k-endpoint-through-proxy#subdirectory=ops

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ ops.manifest>=1.1.3,<2.0.0
 pydantic==1.*
 ops.interface-kube_control == 0.2.0
 ops.interface-tls-certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@236e089493c96feac5ea1a8617b1059a4477a04e#subdirectory=ops
-ops.interface_openstack_integration @ git+https://github.com/canonical/interface-openstack-integration.git@KU-3229/support-o7k-endpoint-through-proxy#subdirectory=ops
+ops.interface_openstack_integration @ git+https://github.com/canonical/interface-openstack-integration.git@cf4383999b0920b226104299f4defb3576680d72#subdirectory=ops

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ ops.manifest>=1.1.3,<2.0.0
 pydantic==1.*
 ops.interface-kube_control == 0.2.0
 ops.interface-tls-certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@236e089493c96feac5ea1a8617b1059a4477a04e#subdirectory=ops
-ops.interface_openstack_integration @ git+https://github.com/canonical/interface-openstack-integration.git@cf4383999b0920b226104299f4defb3576680d72#subdirectory=ops
+ops.interface_openstack_integration @ git+https://github.com/charmed-kubernetes/interface-openstack-integration.git@cf4383999b0920b226104299f4defb3576680d72#subdirectory=ops

--- a/src/provider_manifests.py
+++ b/src/provider_manifests.py
@@ -7,7 +7,7 @@ import json
 import logging
 from typing import Dict, Optional
 
-import jmodelproxylib
+import charms.proxylib
 from lightkube.codecs import AnyResource, from_dict
 from ops.interface_kube_control import KubeControlRequirer
 from ops.interface_openstack_integration import OpenstackIntegrationRequirer
@@ -52,7 +52,7 @@ class CreateSecret(Addition):
 class UpdateDaemonSet(Patch):
     """Update the CCM DaemonSets."""
 
-    def __call__(self, obj):
+    def __call__(self, obj: AnyResource):
         """Patch the openstack CCM daemonset."""
         if not (obj.kind == "DaemonSet" and obj.metadata.name == RESOURCE_NAME):
             return
@@ -79,9 +79,9 @@ class UpdateDaemonSet(Patch):
                         env.value = cluster_name
                         log.info(f"{msg} by env")
 
-                enabled = self.manifests.config.get("juju-model-proxy-enable")
-                env = jmodelproxylib.environ(enabled=enabled, add_no_proxies=K8S_DEFAULT_NO_PROXY)
-                container.env.extend(jmodelproxylib.container_vars(env))
+                enabled = self.manifests.config.get("web-proxy-enable")
+                env = charms.proxylib.environ(enabled=enabled, add_no_proxies=K8S_DEFAULT_NO_PROXY)
+                container.env.extend(charms.proxylib.container_vars(env))
 
 
 class ProviderManifests(Manifests):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -48,6 +48,7 @@ def integrator():
         integrator.evaluate_relation.return_value = None
         integrator.cloud_conf_b64 = b"abc"
         integrator.endpoint_tls_ca = b"def"
+        integrator.proxy_config = {}
         yield integrator
 
 

--- a/tests/unit/test_provider_manifest.py
+++ b/tests/unit/test_provider_manifest.py
@@ -3,6 +3,7 @@
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
+import os
 import unittest.mock as mock
 
 import pytest
@@ -21,15 +22,34 @@ PROXY_URL_2 = f"{PROXY_URL}82"
 NO_PROXY = "127.0.0.1,localhost,::1,example.com"
 
 
+@pytest.fixture(params=["", NO_PROXY])
+def no_proxy(request):
+    """Return the no_proxy value."""
+    return request.param
+
+
+@pytest.fixture(params=[True, False])
+def respect_proxy(request):
+    """Return the juju model proxy enable value."""
+    return request.param
+
+
 @pytest.fixture
-def charm_config():
+def charm_config(respect_proxy, no_proxy):
     """Return the charm config."""
     config = mock.MagicMock(spec=CharmConfig)
     config.available_data = {
         "cloud-conf": "abc",
         "endpoint-ca-cert": "def",
+        "juju-model-proxy-enable": respect_proxy,
     }
-    return config
+    env = {
+        "JUJU_CHARM_HTTP_PROXY": PROXY_URL_1,
+        "JUJU_CHARM_HTTPS_PROXY": PROXY_URL_2,
+        "JUJU_CHARM_NO_PROXY": no_proxy,
+    }
+    with mock.patch.dict(os.environ, env, clear=True):
+        yield config
 
 
 @pytest.fixture
@@ -43,27 +63,13 @@ def kube_control():
     return kube_control
 
 
-@pytest.fixture(params=[None, "", NO_PROXY])
-def no_proxy(request):
-    """Return the no_proxy value."""
-    return request.param
-
-
 @pytest.fixture
-def integrator(no_proxy):
+def integrator():
     """Return the openstack integration mock."""
     integrator = mock.MagicMock(spec=OpenstackIntegrationRequirer)
     integrator.evaluate_relation.return_value = None
     integrator.cloud_conf_b64 = b"abc"
     integrator.endpoint_tls_ca = b"def"
-    integrator.proxy_config = {
-        "HTTP_PROXY": PROXY_URL_1,
-        "HTTPS_PROXY": PROXY_URL_2,
-        "NO_PROXY": no_proxy,
-        "http_proxy": PROXY_URL_1,
-        "https_proxy": PROXY_URL_2,
-        "no_proxy": no_proxy,
-    }
     return integrator
 
 
@@ -78,7 +84,7 @@ def provider(kube_control, charm_config, integrator):
     )
 
 
-def test_patch_daemon_set(provider, no_proxy):
+def test_patch_daemon_set(provider, respect_proxy, no_proxy):
     """Test the patching of the daemon set."""
 
     update_ds = provider.manipulations[-1]
@@ -95,15 +101,24 @@ def test_patch_daemon_set(provider, no_proxy):
     container.name = ds.metadata.name = "openstack-cloud-controller-manager"
     ds.spec.template.spec.volumes = [secret_volume]
     ds.spec.template.spec.containers = [container]
-    split_no_proxy = no_proxy.split(",") if no_proxy else []
-    expected_no_proxy = ",".join(dict.fromkeys(K8S_DEFAULT_NO_PROXY + split_no_proxy))
 
     update_ds(ds)
     assert secret_volume.secret.secretName == "cloud-controller-config"
     assert EnvVar(name="CLUSTER_NAME", value=CLUSTER_NAME) in container.env
-    assert EnvVar(name="HTTP_PROXY", value=PROXY_URL_1) in container.env
-    assert EnvVar(name="HTTPS_PROXY", value=PROXY_URL_2) in container.env
-    assert EnvVar(name="NO_PROXY", value=expected_no_proxy) in container.env
-    assert EnvVar(name="http_proxy", value=PROXY_URL_1) in container.env
-    assert EnvVar(name="https_proxy", value=PROXY_URL_2) in container.env
-    assert EnvVar(name="no_proxy", value=expected_no_proxy) in container.env
+    if respect_proxy:
+        split_no_proxy = no_proxy.split(",") if no_proxy else []
+        expected_no_proxy = ",".join(dict.fromkeys(K8S_DEFAULT_NO_PROXY + split_no_proxy))
+        assert EnvVar(name="HTTP_PROXY", value=PROXY_URL_1) in container.env
+        assert EnvVar(name="HTTPS_PROXY", value=PROXY_URL_2) in container.env
+        assert EnvVar(name="NO_PROXY", value=expected_no_proxy) in container.env
+        assert EnvVar(name="http_proxy", value=PROXY_URL_1) in container.env
+        assert EnvVar(name="https_proxy", value=PROXY_URL_2) in container.env
+        assert EnvVar(name="no_proxy", value=expected_no_proxy) in container.env
+    else:
+        keys = {e.name for e in container.env}
+        assert "HTTP_PROXY" not in keys
+        assert "HTTPS_PROXY" not in keys
+        assert "NO_PROXY" not in keys
+        assert "http_proxy" not in keys
+        assert "https_proxy" not in keys
+        assert "no_proxy" not in keys

--- a/tests/unit/test_provider_manifest.py
+++ b/tests/unit/test_provider_manifest.py
@@ -41,7 +41,7 @@ def charm_config(respect_proxy, no_proxy):
     config.available_data = {
         "cloud-conf": "abc",
         "endpoint-ca-cert": "def",
-        "juju-model-proxy-enable": respect_proxy,
+        "web-proxy-enable": respect_proxy,
     }
     env = {
         "JUJU_CHARM_HTTP_PROXY": PROXY_URL_1,

--- a/tests/unit/test_provider_manifest.py
+++ b/tests/unit/test_provider_manifest.py
@@ -1,0 +1,93 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Learn more about testing at: https://juju.is/docs/sdk/testing
+
+import unittest.mock as mock
+
+import pytest
+from lightkube.models.core_v1 import Container, EnvVar, Volume
+from lightkube.resources.apps_v1 import DaemonSet
+
+import provider_manifests
+from charm import KubeControlRequirer, OpenstackIntegrationRequirer, ProviderCharm
+from config import CharmConfig
+
+CLUSTER_NAME = "k8s-cluster-name"
+PROXY_URL = "http://proxy:80"
+PROXY_URL_1 = f"{PROXY_URL}81"
+PROXY_URL_2 = f"{PROXY_URL}82"
+NO_PROXY = "127.0.0.1,localhost,::1"
+
+
+@pytest.fixture
+def charm_config():
+    """Return the charm config."""
+    config = mock.MagicMock(spec=CharmConfig)
+    config.available_data = {
+        "cloud-conf": b"abc",
+        "endpoint-ca-cert": b"def",
+    }
+    return config
+
+
+@pytest.fixture
+def kube_control():
+    """Return the kube control mock."""
+    kube_control = mock.MagicMock(spec=KubeControlRequirer)
+    kube_control.evaluate_relation.return_value = None
+    kube_control.kubeconfig = b"abc"
+    kube_control.get_cluster_tag.return_value = CLUSTER_NAME
+    return kube_control
+
+
+@pytest.fixture
+def integrator():
+    """Return the openstack integration mock."""
+    integrator = mock.MagicMock(spec=OpenstackIntegrationRequirer)
+    integrator.evaluate_relation.return_value = None
+    integrator.cloud_conf_b64 = b"abc"
+    integrator.endpoint_tls_ca = b"def"
+    integrator.proxy_config = {
+        "HTTP_PROXY": PROXY_URL_1,
+        "HTTPS_PROXY": PROXY_URL_2,
+        "NO_PROXY": NO_PROXY,
+    }
+    return integrator
+
+
+@pytest.fixture
+def provider(kube_control, charm_config, integrator):
+    """Return the manifests object."""
+    yield provider_manifests.ProviderManifests(
+        mock.MagicMock(spec=ProviderCharm),
+        charm_config,
+        kube_control,
+        integrator,
+    )
+
+
+def test_patch_daemon_set(provider):
+    """Test the patching of the daemon set."""
+
+    update_ds = provider.manipulations[-1]
+    assert isinstance(update_ds, provider_manifests.UpdateDaemonSet)
+
+    secret_volume = mock.MagicMock(spec=Volume)
+    cluster_env = EnvVar(name="CLUSTER_NAME", value="set-me")
+
+    container = mock.MagicMock(spec=Container)
+    container.env = [cluster_env]
+
+    ds = mock.MagicMock(spec=DaemonSet)
+    ds.kind = "DaemonSet"
+    container.name = ds.metadata.name = "openstack-cloud-controller-manager"
+    ds.spec.template.spec.volumes = [secret_volume]
+    ds.spec.template.spec.containers = [container]
+
+    update_ds(ds)
+    assert secret_volume.secret.secretName == "cloud-controller-config"
+    assert EnvVar(name="CLUSTER_NAME", value=CLUSTER_NAME) in container.env
+    assert EnvVar(name="HTTP_PROXY", value=PROXY_URL_1) in container.env
+    assert EnvVar(name="HTTPS_PROXY", value=PROXY_URL_2) in container.env
+    assert EnvVar(name="NO_PROXY", value=NO_PROXY) in container.env

--- a/tests/unit/test_provider_manifest.py
+++ b/tests/unit/test_provider_manifest.py
@@ -12,6 +12,7 @@ from lightkube.resources.apps_v1 import DaemonSet
 import provider_manifests
 from charm import KubeControlRequirer, OpenstackIntegrationRequirer, ProviderCharm
 from config import CharmConfig
+from provider_manifests import K8S_DEFAULT_SVC
 
 CLUSTER_NAME = "k8s-cluster-name"
 PROXY_URL = "http://proxy:80"
@@ -25,8 +26,8 @@ def charm_config():
     """Return the charm config."""
     config = mock.MagicMock(spec=CharmConfig)
     config.available_data = {
-        "cloud-conf": b"abc",
-        "endpoint-ca-cert": b"def",
+        "cloud-conf": "abc",
+        "endpoint-ca-cert": "def",
     }
     return config
 
@@ -36,6 +37,7 @@ def kube_control():
     """Return the kube control mock."""
     kube_control = mock.MagicMock(spec=KubeControlRequirer)
     kube_control.evaluate_relation.return_value = None
+    kube_control.get_registry_location.return_value = "rocks.canonical.com/cdk"
     kube_control.kubeconfig = b"abc"
     kube_control.get_cluster_tag.return_value = CLUSTER_NAME
     return kube_control
@@ -90,4 +92,4 @@ def test_patch_daemon_set(provider):
     assert EnvVar(name="CLUSTER_NAME", value=CLUSTER_NAME) in container.env
     assert EnvVar(name="HTTP_PROXY", value=PROXY_URL_1) in container.env
     assert EnvVar(name="HTTPS_PROXY", value=PROXY_URL_2) in container.env
-    assert EnvVar(name="NO_PROXY", value=NO_PROXY) in container.env
+    assert EnvVar(name="NO_PROXY", value=f"{K8S_DEFAULT_SVC},{NO_PROXY}") in container.env

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ description = Run unit tests
 deps =
     pytest
     pytest-cov
+    pytest-sugar
     -r{toxinidir}/requirements.txt
 commands =
     pytest \


### PR DESCRIPTION
Resolves: [LP#2104884](https://bugs.launchpad.net/charm-openstack-integrator/+bug/2104884)

### Overview
1) Contact O7K endpoints through the http proxy settings determined by the `juju-model-proxy-enable` config

### Details
this dictionary will be filled by the `juju model-config` with the following env variables: 
* `juju-http-proxy` --> `HTTP_PROXY`
* `juju-https-proxy` --> `HTTPS_PROXY`
* `juju-no-proxy` --> `NO_PROXY`
* `juju-http-proxy` --> `http_proxy`
* `juju-http-proxy` --> `https_proxy`
* `juju-http-proxy` --> `no_proxy`

The storage-manifest ensures that both `no_proxy` and `NO_PROXY` have specific hostname carve-outs for in cluster domains