### PR TITLE
Restart CCM DaemonSet when config hash changes

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -213,7 +213,7 @@ class ProviderCharm(ops.CharmBase):
                 controller.apply_manifests()
             except ManifestClientError as e:
                 self.unit.status = ops.WaitingStatus("Waiting for kube-apiserver")
-                log.warn(f"Encountered retryable installation error: {e}")
+                log.warning(f"Encountered installation error: {e}")
                 event.defer()
                 return False
         return True

--- a/src/provider_manifests.py
+++ b/src/provider_manifests.py
@@ -98,17 +98,13 @@ class ProviderManifests(Manifests):
     @property
     def config(self) -> Dict:
         """Returns current config available from charm config and joined relations."""
-        config: Dict = {}
-
-        if self.kube_control.is_ready:
-            config["image-registry"] = self.kube_control.get_registry_location()
-            config["cluster-name"] = self.kube_control.get_cluster_tag()
-
-        if self.integrator.is_ready:
-            config["cloud-conf"] = self.integrator.cloud_conf_b64.decode()
-            config["endpoint-ca-cert"] = self.integrator.endpoint_tls_ca.decode()
-
-        config.update(**self.charm_config.available_data)
+        config = {
+            "image-registry": self.kube_control.get_registry_location(),
+            "cluster-name": self.kube_control.get_cluster_tag(),
+            "cloud-conf": (val := self.integrator.cloud_conf_b64) and val.decode(),
+            "endpoint-ca-cert": (val := self.integrator.endpoint_tls_ca) and val.decode(),
+            **self.charm_config.available_data,
+        }
 
         for key, value in dict(**config).items():
             if value == "" or value is None:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -162,6 +162,7 @@ def test_waits_for_kube_control(mock_create_kubeconfig, harness, caplog):
     assert storage_messages == {
         "Encode secret data for cloud-controller.",
         "Patching cluster-name for DaemonSet/openstack-cloud-controller-manager by env",
+        "Setting hash for DaemonSet/openstack-cloud-controller-manager",
         "Setting secret for DaemonSet/openstack-cloud-controller-manager",
     }
 


### PR DESCRIPTION
Resolves: [LP#2107563](https://bugs.launchpad.net/charm-openstack-cloud-controller/+bug/2107563)

### Overview
By annotating the daemonset's spec.template.metadata, if the config hash changes, the DS will restart the pods.