### PR TITLE
pin setup-tools for noble and jammy

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -6,11 +6,11 @@ bases:
   - build-on:
       - name: ubuntu
         channel: "22.04"
-        architectures: 
+        architectures:
           - amd64
     run-on:
       - name: ubuntu
-        channel: "20.04"
+        channel: "22.04"
         architectures:
           - amd64
           - arm64

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydantic==1.*
 ops.interface-kube-control @ git+https://github.com/charmed-kubernetes/interface-kube-control.git@ops-0.2.0#subdirectory=ops
 ops.interface-tls-certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@236e089493c96feac5ea1a8617b1059a4477a04e#subdirectory=ops
 ops.interface_openstack_integration @ git+https://github.com/charmed-kubernetes/interface-openstack-integration.git@d05f2f1a392cabdd15a1ab8348a0e546c32519f7#subdirectory=ops
+setuptools == 79.0.1


### PR DESCRIPTION
* pins setuptools used by python 3.10 and 3.12 
* overrides charmcraft 2.x's default of `setuptools-59.6.0`

Similar to:
* https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/191
* https://github.com/charmed-kubernetes/charm-kubernetes-e2e/pull/40
* https://github.com/charmed-kubernetes/charm-calico/pull/119
* https://github.com/charmed-kubernetes/charm-kubeapi-load-balancer/pull/46
* https://github.com/charmed-kubernetes/charm-kube-ovn/pull/60