### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ The charm requires openstack credentials and connection information, which
 can be provided via the `openstack-integration` relation to the 
 [Openstack Integrator charm](https://charmhub.io/openstack-integrator).
 
+### Release Selection
+
+When setting `manager-release`, manifests for that version must already be
+present in the charm source tree under
+`upstream/controller_manager/manifests`.
+
+You can verify supported versions via:
+
+```bash
+juju run openstack-cloud-controller/leader list-versions --wait
+```
+
 
 ## Deployment
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -24,5 +24,8 @@ parts:
     build-packages:
       - git
     charm-python-packages: [setuptools, pip]
+  upstream-manifests:
+    plugin: dump
+    source: .
     prime:
       - upstream/**

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -25,6 +25,7 @@ parts:
       - git
       - libssl-dev
       - pkg-config
+      - libffi-dev
     charm-python-packages: [setuptools, pip]
   upstream-manifests:
     plugin: dump

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -23,6 +23,8 @@ parts:
   charm:
     build-packages:
       - git
+      - libssl-dev
+      - pkg-config
     charm-python-packages: [setuptools, pip]
   upstream-manifests:
     plugin: dump

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,12 @@
 options:
+  cluster-name:
+    type: string
+    default: ""
+    description: |
+      Override the cluster name passed to openstack-cloud-controller-manager.
+
+      If unset, the charm uses the kube-control relation cluster tag.
+
   image-registry:
     type: string
     description: |

--- a/config.yaml
+++ b/config.yaml
@@ -25,13 +25,14 @@ options:
     type: string
     description: |
       Specify the version of controller-manager-release as defined by the `release`
-      tags of https://github.com/kubernetes/cloud-provider-openstack
-
-      example)
+      tags of https://github.com/kubernetes/cloud-provider-openstack example)
         juju config openstack-cloud-controller manager-release='v1.7.3'
 
+      The manifests for the configured version must already be present in this
+      charm source tree under upstream/controller_manager/manifests.
+      
       A list of supported versions is available through the action:
-        juju run-action openstack-cloud-controller/leader list-releases --wait
+        juju run- openstack-cloud-controller/leader list-versions --wait
 
       To reset by to the latest supported by the charm use:
         juju config openstack-cloud-controller --reset manager-release

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ ops.interface-kube_control==0.2.0
 ops.interface-tls-certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@236e089493c96feac5ea1a8617b1059a4477a04e#subdirectory=ops
 ops.interface_openstack_integration @ git+https://github.com/charmed-kubernetes/interface-openstack-integration.git@d05f2f1a392cabdd15a1ab8348a0e546c32519f7#subdirectory=ops
 charms.proxylib == 0.0.0
+openstacksdk==3.0.0
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -3,16 +3,19 @@
 # See LICENSE file for licensing details.
 """Deploy and manage the Controller-Manager for K8s on OpenStack."""
 
+import base64
+import json
 import logging
 import os
 import shutil
 from pathlib import Path
-from typing import List
+from typing import Dict, List, Optional
 
 import ops
 from lightkube import Client
 from lightkube.core.exceptions import ApiError
 from lightkube.resources.core_v1 import Node
+from openstack import connection as openstack_connection
 from ops.interface_kube_control import KubeControlRequirer
 from ops.interface_openstack_integration import OpenstackIntegrationRequirer
 from ops.interface_tls_certificates import CertificatesRequires
@@ -56,6 +59,7 @@ class ProviderCharm(ops.CharmBase):
         self.framework.observe(self.on.kube_control_relation_created, self._kube_control)
         self.framework.observe(self.on.kube_control_relation_joined, self._kube_control)
         self.framework.observe(self.on.kube_control_relation_changed, self._merge_config)
+        self.framework.observe(self.on.kube_control_relation_departed, self._pre_teardown)
         self.framework.observe(self.on.kube_control_relation_broken, self._merge_config)
 
         self.framework.observe(self.on.certificates_relation_created, self._merge_config)
@@ -68,6 +72,7 @@ class ProviderCharm(ops.CharmBase):
         self.framework.observe(self.on.openstack_relation_created, self._merge_config)
         self.framework.observe(self.on.openstack_relation_joined, self._merge_config)
         self.framework.observe(self.on.openstack_relation_changed, self._merge_config)
+        self.framework.observe(self.on.openstack_relation_departed, self._pre_teardown)
         self.framework.observe(self.on.openstack_relation_broken, self._merge_config)
 
         self.framework.observe(self.on.list_versions_action, self._list_versions)
@@ -91,6 +96,10 @@ class ProviderCharm(ops.CharmBase):
         os.environ["KUBECONFIG"] = path
         return Path(path)
 
+    @property
+    def _openstack_ca_cert_path(self) -> Path:
+        return Path(f"/srv/{self.unit.name}/openstack-endpoint-ca.crt")
+
     def _list_versions(self, event):
         self.collector.list_versions(event)
 
@@ -113,6 +122,119 @@ class ProviderCharm(ops.CharmBase):
             msg = "Failed to apply missing resources. API Server unavailable."
             event.set_results({"result": msg})
 
+    @staticmethod
+    def _decode_relation_value(value):
+        """Decode quoted JSON-style relation values into native Python values."""
+        if not isinstance(value, str):
+            return value
+        value = value.strip()
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+
+    def _openstack_relation_data(self) -> Dict[str, str]:
+        """Return the remote relation data for the openstack relation."""
+        relation = getattr(self.integrator, "relation", None)
+        if not relation or not relation.units:
+            return {}
+        try:
+            unit = next(iter(relation.units))
+        except StopIteration:
+            return {}
+        return dict(relation.data[unit])
+
+    def _openstack_connection(self) -> Optional[openstack_connection.Connection]:
+        """Build an OpenStack SDK connection from relation data."""
+        relation_data = self._openstack_relation_data()
+        if not relation_data:
+            log.info("OpenStack relation data is not yet available for providerID lookup.")
+            return None
+
+        decoded = {key: self._decode_relation_value(value) for key, value in relation_data.items()}
+        auth_url = decoded.get("auth_url")
+        if not auth_url:
+            log.warning("OpenStack relation data is missing auth_url; cannot resolve providerIDs.")
+            return None
+
+        conn_args = {
+            "auth_url": auth_url,
+            "region_name": decoded.get("region") or None,
+            "identity_api_version": str(decoded.get("version") or "3"),
+        }
+
+        endpoint_tls_ca = decoded.get("endpoint_tls_ca")
+        if endpoint_tls_ca:
+            self._openstack_ca_cert_path.write_bytes(base64.b64decode(endpoint_tls_ca))
+            conn_args["verify"] = str(self._openstack_ca_cert_path)
+
+        if decoded.get("application_credential_id") and decoded.get(
+            "application_credential_secret"
+        ):
+            conn_args.update(
+                {
+                    "auth_type": "v3applicationcredential",
+                    "application_credential_id": decoded["application_credential_id"],
+                    "application_credential_secret": decoded["application_credential_secret"],
+                }
+            )
+            log.info("Using OpenStack application credentials for providerID lookup.")
+        else:
+            required = {
+                "username": decoded.get("username"),
+                "password": decoded.get("password"),
+                "project_name": decoded.get("project_name"),
+                "user_domain_name": decoded.get("user_domain_name"),
+                "project_domain_name": decoded.get("project_domain_name"),
+            }
+            missing = [key for key, value in required.items() if not value]
+            if missing:
+                log.warning(
+                    "OpenStack relation data is missing %s; cannot resolve providerIDs.",
+                    ", ".join(sorted(missing)),
+                )
+                return None
+            conn_args.update(required)
+            log.info("Using OpenStack username/password credentials for providerID lookup.")
+
+        return openstack_connection.Connection(**conn_args)
+
+    @staticmethod
+    def _node_internal_ip(node: Node) -> Optional[str]:
+        """Extract the first InternalIP from a Kubernetes node."""
+        for address in getattr(node.status, "addresses", []) or []:
+            if address.type == "InternalIP" and address.address:
+                return address.address
+        return None
+
+    @staticmethod
+    def _server_ips(server) -> List[str]:
+        """Extract all IP addresses from an OpenStack server object."""
+        ips = []
+        for network in (getattr(server, "addresses", {}) or {}).values():
+            if not isinstance(network, list):
+                continue
+            for address in network:
+                if isinstance(address, dict) and address.get("addr"):
+                    ips.append(address["addr"])
+        return ips
+
+    def _servers_by_internal_ip(self) -> Dict[str, List[str]]:
+        """Map OpenStack server IPs to providerID values."""
+        conn = self._openstack_connection()
+        if not conn:
+            return {}
+
+        servers_by_ip: Dict[str, List[str]] = {}
+        for server in conn.compute.servers(details=True):
+            provider_id = f"openstack:///{server.id}"
+            for ip in self._server_ips(server):
+                servers_by_ip.setdefault(ip, []).append(provider_id)
+        log.info(
+            "Loaded %d OpenStack server IP mappings for providerID lookup.", len(servers_by_ip)
+        )
+        return servers_by_ip
+
     def _check_node_provider_ids(self) -> List[str]:
         """Check nodes for missing or invalid providerIDs.
 
@@ -122,12 +244,49 @@ class ProviderCharm(ops.CharmBase):
         try:
             client = Client()
             nodes_without_provider_id = []
+            servers_by_ip = self._servers_by_internal_ip()
 
             for node in client.list(Node):
                 provider_id = node.spec.providerID if node.spec.providerID else ""
                 # Expected format: "openstack://region/InstanceID" or "openstack:///InstanceID"
                 if not provider_id.startswith("openstack://"):
-                    nodes_without_provider_id.append(node.metadata.name)
+                    internal_ip = self._node_internal_ip(node)
+                    if not internal_ip:
+                        log.info(
+                            "Node %s has no InternalIP; cannot resolve providerID.",
+                            node.metadata.name,
+                        )
+                        nodes_without_provider_id.append(node.metadata.name)
+                        continue
+
+                    matches = servers_by_ip.get(internal_ip, [])
+                    if len(matches) > 1:
+                        log.warning(
+                            "Found multiple OpenStack matches for node %s InternalIP %s; skipping providerID patch.",
+                            node.metadata.name,
+                            internal_ip,
+                        )
+                        nodes_without_provider_id.append(node.metadata.name)
+                        continue
+                    if not matches:
+                        log.info(
+                            "No OpenStack server match found for node %s InternalIP %s.",
+                            node.metadata.name,
+                            internal_ip,
+                        )
+                        nodes_without_provider_id.append(node.metadata.name)
+                        continue
+
+                    patched_provider_id = matches[0]
+                    log.info(
+                        "Patching providerID for node %s using InternalIP %s -> %s.",
+                        node.metadata.name,
+                        internal_ip,
+                        patched_provider_id,
+                    )
+                    client.patch(
+                        Node, node.metadata.name, {"spec": {"providerID": patched_provider_id}}
+                    )
 
             return nodes_without_provider_id
         except ApiError as e:

--- a/src/charm.py
+++ b/src/charm.py
@@ -267,16 +267,21 @@ class ProviderCharm(ops.CharmBase):
                 return False
         return True
 
+    def _pre_teardown(self, event):
+        """Delete manifests before a relation is removed, while credentials are still valid."""
+        if not self.unit.is_leader() or not self.stored.config_hash:
+            return
+        if self.app.planned_units() != 0:
+            return
+        self.unit.status = ops.MaintenanceStatus("Cleaning up Cloud Controller Manager")
+        for controller in self.collector.manifests.values():
+            try:
+                controller.delete_manifests(ignore_unauthorized=True)
+            except ManifestClientError:
+                log.warning("Failed to delete manifests during relation teardown")
+        self.stored.config_hash = None
+
     def _cleanup(self, event):
-        if self.stored.config_hash:
-            self.unit.status = ops.MaintenanceStatus("Cleaning up Cloud Controller Manager")
-            for controller in self.collector.manifests.values():
-                try:
-                    controller.delete_manifests(ignore_unauthorized=True)
-                except ManifestClientError:
-                    self.unit.status = ops.WaitingStatus("Waiting for kube-apiserver")
-                    event.defer()
-                    return
         self.unit.status = ops.MaintenanceStatus("Shutting down")
         if self._kubeconfig_path.parent.is_dir() and self._kubeconfig_path.parent.exists():
             shutil.rmtree(self._kubeconfig_path.parent)

--- a/src/charm.py
+++ b/src/charm.py
@@ -159,7 +159,8 @@ class ProviderCharm(ops.CharmBase):
 
         self.unit.status = ops.ActiveStatus("Ready")
         self.unit.set_workload_version(self.collector.short_version)
-        self.app.status = ops.ActiveStatus(self.collector.long_version)
+        if self.unit.is_leader():
+            self.app.status = ops.ActiveStatus(self.collector.long_version)
 
     def _kube_control(self, event):
         self.kube_control.set_auth_request(self.unit.name, "system:masters")
@@ -247,6 +248,11 @@ class ProviderCharm(ops.CharmBase):
     def _install_or_upgrade(self, event, config_hash=None):
         if self.stored.config_hash == config_hash:
             log.info("Skipping until the config is evaluated.")
+            return True
+
+        if not self.unit.is_leader():
+            self.unit.status = ops.ActiveStatus("Ready (standby)")
+            log.info("Skipping manifest apply on non-leader unit")
             return True
 
         self.unit.status = ops.MaintenanceStatus("Deploying Cloud Controller Manager")

--- a/src/provider_manifests.py
+++ b/src/provider_manifests.py
@@ -148,6 +148,14 @@ class ProviderManifests(Manifests):
 
     def evaluate(self) -> Optional[str]:
         """Determine if manifest_config can be applied to manifests."""
+        configured_release = self.config.get("release")
+        if configured_release and configured_release not in self.releases:
+            supported = ", ".join(self.releases)
+            return (
+                f"manager-release '{configured_release}' is not supported. "
+                f"Available releases: {supported}"
+            )
+
         for prop in ["cloud-conf", "cluster-name"]:
             if not self.config.get(prop):
                 return f"Provider manifests waiting for definition of {prop}"

--- a/src/provider_manifests.py
+++ b/src/provider_manifests.py
@@ -124,7 +124,10 @@ class ProviderManifests(Manifests):
     @property
     def config(self) -> Dict:
         """Returns current config available from charm config and joined relations."""
-        cluster_name = self.charm_config.available_data.get("cluster-name") or self.kube_control.get_cluster_tag()
+        cluster_name = (
+            self.charm_config.available_data.get("cluster-name")
+            or self.kube_control.get_cluster_tag()
+        )
         config = {
             "image-registry": self.kube_control.get_registry_location(),
             "cluster-name": cluster_name,

--- a/src/provider_manifests.py
+++ b/src/provider_manifests.py
@@ -124,9 +124,10 @@ class ProviderManifests(Manifests):
     @property
     def config(self) -> Dict:
         """Returns current config available from charm config and joined relations."""
+        cluster_name = self.charm_config.available_data.get("cluster-name") or self.kube_control.get_cluster_tag()
         config = {
             "image-registry": self.kube_control.get_registry_location(),
-            "cluster-name": self.kube_control.get_cluster_tag(),
+            "cluster-name": cluster_name,
             "cloud-conf": (val := self.integrator.cloud_conf_b64) and val.decode(),
             "endpoint-ca-cert": (val := self.integrator.endpoint_tls_ca) and val.decode(),
             **self.charm_config.available_data,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,6 +3,7 @@
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
+import shutil
 import unittest.mock as mock
 from pathlib import Path
 
@@ -130,6 +131,7 @@ def test_waits_for_certificates(harness):
 @mock.patch("ops.interface_kube_control.KubeControlRequirer.create_kubeconfig")
 @pytest.mark.usefixtures("integrator", "certificates")
 def test_waits_for_kube_control(mock_create_kubeconfig, harness, caplog):
+    harness.set_leader(True)
     harness.begin_with_initial_hooks()
     charm = harness.charm
     assert isinstance(charm.unit.status, BlockedStatus)
@@ -170,3 +172,190 @@ def test_waits_for_kube_control(mock_create_kubeconfig, harness, caplog):
     }
 
     caplog.clear()
+
+
+def _mock_node(name: str, provider_id: str, internal_ip: str):
+    node = mock.MagicMock()
+    node.metadata.name = name
+    node.spec.providerID = provider_id
+    addr = mock.MagicMock()
+    addr.type = "InternalIP"
+    addr.address = internal_ip
+    node.status.addresses = [addr]
+    return node
+
+
+def test_provider_ids_are_patched_by_internal_ip(harness, lk_client_charm):
+    harness.begin()
+    charm = harness.charm
+    node = _mock_node("node-1", "", "10.0.0.11")
+    lk_client_charm.list.return_value = [node]
+
+    with mock.patch.object(
+        charm, "_servers_by_internal_ip", return_value={"10.0.0.11": ["openstack:///srv-1"]}
+    ):
+        missing = charm._check_node_provider_ids()
+
+    assert missing == []
+    lk_client_charm.patch.assert_called_once_with(
+        mock.ANY, "node-1", {"spec": {"providerID": "openstack:///srv-1"}}
+    )
+
+
+def test_provider_ids_missing_when_no_internal_ip_match(harness, lk_client_charm):
+    harness.begin()
+    charm = harness.charm
+    node = _mock_node("node-1", "", "10.0.0.11")
+    lk_client_charm.list.return_value = [node]
+
+    with mock.patch.object(charm, "_servers_by_internal_ip", return_value={}):
+        missing = charm._check_node_provider_ids()
+
+    assert missing == ["node-1"]
+    lk_client_charm.patch.assert_not_called()
+
+
+def test_provider_ids_not_patched_when_already_set(harness, lk_client_charm):
+    harness.begin()
+    charm = harness.charm
+    node = _mock_node("node-1", "openstack:///srv-1", "10.0.0.11")
+    lk_client_charm.list.return_value = [node]
+
+    with mock.patch.object(
+        charm, "_servers_by_internal_ip", return_value={"10.0.0.11": ["openstack:///srv-1"]}
+    ):
+        missing = charm._check_node_provider_ids()
+
+    assert missing == []
+    lk_client_charm.patch.assert_not_called()
+
+
+def test_install_or_upgrade_skips_apply_on_non_leader(harness):
+    harness.begin()
+    harness.set_leader(False)
+    charm = harness.charm
+    controller = mock.MagicMock()
+    charm.collector.manifests = {"provider": controller}
+    charm.stored.config_hash = None
+
+    assert charm._install_or_upgrade(mock.MagicMock(), config_hash=1) is True
+    controller.apply_manifests.assert_not_called()
+
+
+def test_install_or_upgrade_applies_on_leader(harness):
+    harness.begin()
+    harness.set_leader(True)
+    charm = harness.charm
+    controller = mock.MagicMock()
+    charm.collector.manifests = {"provider": controller}
+    charm.stored.config_hash = None
+
+    assert charm._install_or_upgrade(mock.MagicMock(), config_hash=1) is True
+    controller.apply_manifests.assert_called_once_with()
+
+
+def test_cleanup_skips_delete_on_non_leader(harness):
+    harness.begin()
+    harness.set_leader(False)
+    charm = harness.charm
+    controller = mock.MagicMock()
+    charm.collector.manifests = {"provider": controller}
+    charm.stored.config_hash = 1
+
+    charm._cleanup(mock.MagicMock())
+
+    controller.delete_manifests.assert_not_called()
+
+
+def test_cleanup_removes_kubeconfig(harness):
+    harness.begin()
+    charm = harness.charm
+
+    # Mock the kubeconfig path to avoid actual filesystem operations
+    mock_path = mock.MagicMock(spec=Path)
+    mock_path.parent = mock.MagicMock()
+    mock_path.parent.is_dir.return_value = True
+    mock_path.parent.exists.return_value = True
+
+    with mock.patch.object(
+        ProviderCharm,
+        "_kubeconfig_path",
+        new_callable=mock.PropertyMock,
+        return_value=mock_path,
+    ), mock.patch("shutil.rmtree") as mock_rmtree:
+        charm._cleanup(mock.MagicMock())
+        mock_rmtree.assert_called_once_with(mock_path.parent)
+
+
+def test_pre_teardown_skips_if_not_leader(harness):
+    harness.begin()
+    harness.set_leader(False)
+    charm = harness.charm
+    controller = mock.MagicMock()
+    charm.collector.manifests = {"provider": controller}
+    charm.stored.config_hash = 1
+
+    charm._pre_teardown(mock.MagicMock())
+
+    controller.delete_manifests.assert_not_called()
+
+
+def test_pre_teardown_skips_if_not_removal(harness):
+    harness.begin()
+    harness.set_leader(True)
+    harness.set_planned_units(1)  # Not removal (relation swap)
+    charm = harness.charm
+    controller = mock.MagicMock()
+    charm.collector.manifests = {"provider": controller}
+    charm.stored.config_hash = 1
+
+    charm._pre_teardown(mock.MagicMock())
+
+    controller.delete_manifests.assert_not_called()
+
+
+def test_pre_teardown_deletes_on_removal(harness):
+    harness.begin()
+    harness.set_leader(True)
+    harness.set_planned_units(0)  # Removal
+    charm = harness.charm
+    controller = mock.MagicMock()
+    charm.collector.manifests = {"provider": controller}
+    charm.stored.config_hash = 1
+
+    charm._pre_teardown(mock.MagicMock())
+
+    controller.delete_manifests.assert_called_once_with(ignore_unauthorized=True)
+    assert charm.stored.config_hash is None
+
+
+def test_pre_teardown_resets_hash_so_cleanup_skips(harness):
+    harness.begin()
+    harness.set_leader(True)
+    harness.set_planned_units(0)
+    charm = harness.charm
+    controller = mock.MagicMock()
+    charm.collector.manifests = {"provider": controller}
+    charm.stored.config_hash = 1
+
+    # Run pre_teardown
+    charm._pre_teardown(mock.MagicMock())
+
+    # Reset the controller for cleanup
+    controller.reset_mock()
+
+    # Mock the kubeconfig path to avoid actual filesystem operations
+    mock_path = mock.MagicMock(spec=Path)
+    mock_path.parent = mock.MagicMock()
+    mock_path.parent.is_dir.return_value = True
+    mock_path.parent.exists.return_value = True
+
+    with mock.patch.object(
+        ProviderCharm,
+        "_kubeconfig_path",
+        new_callable=mock.PropertyMock,
+        return_value=mock_path,
+    ), mock.patch("shutil.rmtree"):
+        charm._cleanup(mock.MagicMock())
+
+    controller.delete_manifests.assert_not_called()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,7 +3,6 @@
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
-import shutil
 import unittest.mock as mock
 from pathlib import Path
 
@@ -277,12 +276,15 @@ def test_cleanup_removes_kubeconfig(harness):
     mock_path.parent.is_dir.return_value = True
     mock_path.parent.exists.return_value = True
 
-    with mock.patch.object(
-        ProviderCharm,
-        "_kubeconfig_path",
-        new_callable=mock.PropertyMock,
-        return_value=mock_path,
-    ), mock.patch("shutil.rmtree") as mock_rmtree:
+    with (
+        mock.patch.object(
+            ProviderCharm,
+            "_kubeconfig_path",
+            new_callable=mock.PropertyMock,
+            return_value=mock_path,
+        ),
+        mock.patch("shutil.rmtree") as mock_rmtree,
+    ):
         charm._cleanup(mock.MagicMock())
         mock_rmtree.assert_called_once_with(mock_path.parent)
 
@@ -350,12 +352,15 @@ def test_pre_teardown_resets_hash_so_cleanup_skips(harness):
     mock_path.parent.is_dir.return_value = True
     mock_path.parent.exists.return_value = True
 
-    with mock.patch.object(
-        ProviderCharm,
-        "_kubeconfig_path",
-        new_callable=mock.PropertyMock,
-        return_value=mock_path,
-    ), mock.patch("shutil.rmtree"):
+    with (
+        mock.patch.object(
+            ProviderCharm,
+            "_kubeconfig_path",
+            new_callable=mock.PropertyMock,
+            return_value=mock_path,
+        ),
+        mock.patch("shutil.rmtree"),
+    ):
         charm._cleanup(mock.MagicMock())
 
     controller.delete_manifests.assert_not_called()

--- a/tests/unit/test_provider_manifest.py
+++ b/tests/unit/test_provider_manifest.py
@@ -122,3 +122,20 @@ def test_patch_daemon_set(provider, respect_proxy, no_proxy):
         assert "http_proxy" not in keys
         assert "https_proxy" not in keys
         assert "no_proxy" not in keys
+
+
+def test_evaluate_rejects_unsupported_manager_release(provider, charm_config):
+    """Ensure evaluate blocks when configured manager-release is not present locally."""
+    charm_config.available_data["manager-release"] = "v999.999.999"
+
+    msg = provider.evaluate()
+
+    assert msg is not None
+    assert "manager-release 'v999.999.999' is not supported" in msg
+
+
+def test_evaluate_accepts_supported_manager_release(provider, charm_config):
+    """Ensure evaluate passes when configured manager-release exists locally."""
+    charm_config.available_data["manager-release"] = provider.releases[0]
+
+    assert provider.evaluate() is None

--- a/upstream/controller_manager/manifests/v1.35.0/000-cloud-controller-manager-role-bindings.yaml
+++ b/upstream/controller_manager/manifests/v1.35.0/000-cloud-controller-manager-role-bindings.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:cloud-node-controller
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:cloud-node-controller
+  subjects:
+  - kind: ServiceAccount
+    name: cloud-node-controller
+    namespace: kube-system
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:cloud-controller-manager
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:cloud-controller-manager
+  subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: kube-system
+kind: List
+metadata: {}

--- a/upstream/controller_manager/manifests/v1.35.0/001-cloud-controller-manager-roles.yaml
+++ b/upstream/controller_manager/manifests/v1.35.0/001-cloud-controller-manager-roles.yaml
@@ -1,0 +1,122 @@
+apiVersion: v1
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: system:cloud-controller-manager
+  rules:
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - get
+    - create
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - '*'
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/status
+    verbs:
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    verbs:
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - services/status
+    verbs:
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts
+    verbs:
+    - create
+    - get
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts/token
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    resources:
+    - persistentvolumes
+    verbs:
+    - '*'
+  - apiGroups:
+    - ""
+    resources:
+    - endpoints
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - list
+    - get
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: system:cloud-node-controller
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - '*'
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/status
+    verbs:
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+kind: List
+metadata: {}

--- a/upstream/controller_manager/manifests/v1.35.0/002-openstack-cloud-controller-manager-ds.yaml
+++ b/upstream/controller_manager/manifests/v1.35.0/002-openstack-cloud-controller-manager-ds.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: openstack-cloud-controller-manager
+  namespace: kube-system
+  labels:
+    k8s-app: openstack-cloud-controller-manager
+spec:
+  selector:
+    matchLabels:
+      k8s-app: openstack-cloud-controller-manager
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        k8s-app: openstack-cloud-controller-manager
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+      securityContext:
+        runAsUser: 1001
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Equal"
+        value: "true"
+        effect: "NoExecute"
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
+      serviceAccountName: cloud-controller-manager
+      containers:
+        - name: openstack-cloud-controller-manager
+          image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.35.0
+          args:
+            - /bin/openstack-cloud-controller-manager
+            - --v=1
+            - --cluster-name=$(CLUSTER_NAME)
+            - --cloud-config=$(CLOUD_CONFIG)
+            - --cloud-provider=openstack
+            - --use-service-account-credentials=false
+            - --bind-address=127.0.0.1
+          volumeMounts:
+            - mountPath: /etc/kubernetes/pki
+              name: k8s-certs
+              readOnly: true
+            - mountPath: /etc/ssl/certs
+              name: ca-certs
+              readOnly: true
+            - mountPath: /etc/config
+              name: cloud-config-volume
+              readOnly: true
+          resources:
+            requests:
+              cpu: 200m
+          env:
+            - name: CLOUD_CONFIG
+              value: /etc/config/cloud.conf
+            - name: CLUSTER_NAME
+              value: kubernetes
+      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      volumes:
+      - hostPath:
+          path: /etc/kubernetes/pki
+          type: DirectoryOrCreate
+        name: k8s-certs
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - name: cloud-config-volume
+        secret:
+          secretName: cloud-config


### PR DESCRIPTION
[Multi unit HA](https://bugs.launchpad.net/charm-openstack-integrator/+bug/2157064)
[Update the charms’ source code with v1.35.0 of the upstream manifests](https://bugs.launchpad.net/charm-cinder-csi/+bug/2157065)
[Fail when the upstream manifest is not located in the charm source code](https://bugs.launchpad.net/charm-cinder-csi/+bug/2157066)
[Compute instance provider id for manual juju clouds](https://bugs.launchpad.net/charm-openstack-cloud-controller/+bug/2157067)
[Expose cluster-name as config option](https://bugs.launchpad.net/charm-cinder-csi/+bug/2157068)
Improve removal of cinder-csi and openstack-cloud-controller: [Issue](https://bugs.launchpad.net/charm-cinder-csi/+bug/2157055) for both charms. Some work has been done but some will remain (this is not critical as removal of the juju app is not part of the workflow for SDAIA).