### PR TITLE
Update image-registry default to ghcr.io/canonical/cdk

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,7 @@ options:
       If unset, the manifests will use the image registry from the kube-control relation
 
       example)
-        juju config openstack-cloud-controller image-registry='rocks.canonical.com:443/cdk'
+        juju config openstack-cloud-controller image-registry='ghcr.io/canonical/cdk'
         juju config openstack-cloud-controller --reset image-registry
 
   web-proxy-enable:

--- a/tests/data/kube_control_data.yaml
+++ b/tests/data/kube_control_data.yaml
@@ -27,7 +27,7 @@ has-xcp: "false"
 ingress-address: 10.246.154.7
 port: "53"
 private-address: 10.246.154.7
-registry-location: rocks.canonical.com:443/cdk
+registry-location: ghcr.io/canonical/cdk
 sdn-ip: 10.152.183.20
 taints: '["node-role.kubernetes.io/control-plane=true:NoSchedule"]'
 labels: '["node-role.kubernetes.io/control-plane=true"]'

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -67,7 +67,7 @@ def kube_control():
     with mock.patch("charm.KubeControlRequirer") as mocked:
         kube_control = mocked.return_value
         kube_control.evaluate_relation.return_value = None
-        kube_control.get_registry_location.return_value = "rocks.canonical.com/cdk"
+        kube_control.get_registry_location.return_value = "ghcr.io/canonical/cdk"
         kube_control.get_controller_taints.return_value = []
         kube_control.get_controller_labels.return_value = []
         kube_control.relation.app.name = "kubernetes-control-plane"

--- a/tests/unit/test_provider_manifest.py
+++ b/tests/unit/test_provider_manifest.py
@@ -57,7 +57,7 @@ def kube_control():
     """Return the kube control mock."""
     kube_control = mock.MagicMock(spec=KubeControlRequirer)
     kube_control.evaluate_relation.return_value = None
-    kube_control.get_registry_location.return_value = "rocks.canonical.com/cdk"
+    kube_control.get_registry_location.return_value = "ghcr.io/canonical/cdk"
     kube_control.kubeconfig = b"abc"
     kube_control.get_cluster_tag.return_value = CLUSTER_NAME
     return kube_control

--- a/upstream/README.md
+++ b/upstream/README.md
@@ -14,7 +14,7 @@ tox -e update -- --registry ${upload-registry} ${namespacing-path} ${user} ~/.up
 This will overwrite the existing manifests for the supported components
 This will also synchronize the images to a provided oci-registry
 
-example) uploading to rocks
+example) uploading to ghcr.io
     ```
-    --registry upload.rocks.canonical.com:5000 staging/cdk admin ~/.upload-password
+    --registry ghcr.io/canonical/cdk <user> ~/.ghcr-token
     ```

--- a/upstream/update.py
+++ b/upstream/update.py
@@ -26,7 +26,7 @@ logging.basicConfig(level=logging.INFO)
 GH_REPO = "https://github.com/{repo}"
 GH_TAGS = "https://api.github.com/repos/{repo}/tags"
 GH_RAW = "https://raw.githubusercontent.com/{repo}/{rel}/{path}/{manifest}"
-ROCKS_CC = "upload.rocks.canonical.com:5000/cdk"
+ROCKS_CC = "ghcr.io/canonical/cdk"
 
 SOURCES = dict(
     controller_manager=dict(


### PR DESCRIPTION
`rocks.canonical.com` is being retired. This PR updates the image registry
references from the legacy registry to the new GitHub Container Registry.

**Changes:**
- `rocks.canonical.com:443/cdk` → `ghcr.io/canonical/cdk`
- `rocks.canonical.com/cdk` → `ghcr.io/canonical/cdk`
